### PR TITLE
Adding timer buttons

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,2 +1,4 @@
 module DashboardHelper
+  def default_timer_minutes = 25
+  def mmss_for(minutes) = format("%02d:%02d", minutes.to_i, 0)
 end

--- a/app/views/dashboard/_timer.html.erb
+++ b/app/views/dashboard/_timer.html.erb
@@ -5,14 +5,14 @@
   <%= text_field_tag :task, nil,
         id: "task-input",
         placeholder: "What are you focusing on?",
-        style: "width:100%;padding:8px;margin:4px 0 10px;" %>
+        style: "width:95%;padding:7px;margin:3px 0 10px;" %>
 
   <!-- Length input -->
   <label for="length-input">Length (minutes)</label>
   <%= number_field_tag :length_minutes, default_timer_minutes,
         id: "length-input",
         min: 1, step: 1,
-        style: "width:100%;padding:8px;margin:4px 0 12px;" %>
+        style: "width:95%;padding:7px;margin:3px 0 10px;" %>
 
   <!-- Countdown display (static for now; logic comes later) -->
   <div id="timer-display"

--- a/app/views/dashboard/_timer.html.erb
+++ b/app/views/dashboard/_timer.html.erb
@@ -1,0 +1,29 @@
+<div class="mypomo-card" style="padding:12px;border:1px solid #ddd;border-radius:12px;max-width:460px;">
+  
+  <!-- Task input -->
+  <label for="task-input">Task</label>
+  <%= text_field_tag :task, nil,
+        id: "task-input",
+        placeholder: "What are you focusing on?",
+        style: "width:100%;padding:8px;margin:4px 0 10px;" %>
+
+  <!-- Length input -->
+  <label for="length-input">Length (minutes)</label>
+  <%= number_field_tag :length_minutes, default_timer_minutes,
+        id: "length-input",
+        min: 1, step: 1,
+        style: "width:100%;padding:8px;margin:4px 0 12px;" %>
+
+  <!-- Countdown display (static for now; logic comes later) -->
+  <div id="timer-display"
+       style="font-size:48px;text-align:center;margin:8px 0;">
+    <%= mmss_for(default_timer_minutes) %>
+  </div>
+
+  <!-- Buttons (placeholders in this PR) -->
+  <div style="display:flex;gap:8px;">
+    <%= button_tag "Start", type: "button", style: "flex:1;padding:10px;" %>
+    <%= button_tag "Stop",  type: "button", style: "flex:1;padding:10px;" %>
+    <%= button_tag "Reset", type: "button", style: "flex:1;padding:10px;" %>
+  </div>
+</div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -3,3 +3,5 @@
 
 <div data-controller="hello">Stimulus check</div>
 
+<%= render "timer" %>
+


### PR DESCRIPTION
Resolves and closes issue #32 

## Why
This establishes the one-page layout for MyPomo. Countdown logic will be added in a follow-up Stimulus issue; this PR stays UI-only for easy review.  


## What changed
- New partial `app/views/dashboard/_timer.html.erb` with inputs, buttons, and static display
- Dashboard now renders the partial from `show.html.erb`
- Added `DashboardHelper` methods for default minutes and "MM:SS" formatting

## Screenshots / Demo
- Visiting `/` shows the timer card with fields and buttons; display reads `25:00`.
<img width="1239" height="520" alt="Screenshot 2025-09-23 at 10 12 18 PM" src="https://github.com/user-attachments/assets/630e3e65-bdbc-483e-8765-8f84c5863f61" />

## How to test
1. Check out this branch: adding-timer-buttons
2. `bin/rails s`
3. Visit `/` and verify:
   - Task text input
   - Length input defaulted to 25
   - Display shows `25:00`
   - Start/Stop/Reset buttons present (non-functional yet)

## Risks & Rollout
Low; pure ERB/Ruby UI. No JS logic, no DB changes.

## Checklist
- [x] Lint passes (`bundle exec rubocop`)
- [x] App boots locally
- [x] Acceptance criteria met
